### PR TITLE
improve JSON output for some types

### DIFF
--- a/derive/src/type_def.rs
+++ b/derive/src/type_def.rs
@@ -49,7 +49,7 @@ pub fn generate_impl(input: TokenStream2) -> Result<TokenStream2> {
 	let has_type_def_impl = quote! {
 		impl #impl_generics _type_metadata::HasTypeDef for #ident #ty_generics #where_clause {
 			fn type_def() -> _type_metadata::TypeDef {
-				#def
+				#def.into()
 			}
 		}
 	};

--- a/derive/src/type_def.rs
+++ b/derive/src/type_def.rs
@@ -49,7 +49,7 @@ pub fn generate_impl(input: TokenStream2) -> Result<TokenStream2> {
 	let has_type_def_impl = quote! {
 		impl #impl_generics _type_metadata::HasTypeDef for #ident #ty_generics #where_clause {
 			fn type_def() -> _type_metadata::TypeDef {
-				#def.into()
+				#def
 			}
 		}
 	};

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -69,6 +69,7 @@ impl<T> Symbol<'_, T> {
 pub struct Interner<T> {
 	#[serde(skip)]
 	map: BTreeMap<T, usize>,
+	#[serde(flatten)]
 	vec: Vec<T>,
 }
 

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -22,8 +22,10 @@ use serde::Serialize;
 /// This can be used by self-referential types but
 /// can no longer be used to resolve instances.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
 pub struct UntrackedSymbol<T> {
 	id: NonZeroU32,
+	#[serde(skip)]
 	marker: PhantomData<fn() -> T>,
 }
 
@@ -31,8 +33,10 @@ pub struct UntrackedSymbol<T> {
 ///
 /// Can be used to resolve to the associated instance.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
 pub struct Symbol<'a, T> {
 	id: NonZeroU32,
+	#[serde(skip)]
 	marker: PhantomData<fn() -> &'a T>,
 }
 

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -65,6 +65,7 @@ impl<T> Symbol<'_, T> {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
 pub struct Interner<T> {
 	#[serde(skip)]
 	map: BTreeMap<T, usize>,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -37,6 +37,7 @@ pub struct TypeIdDef {
 
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct Registry {
+	#[serde(rename = "strings")]
 	string_table: Interner<&'static str>,
 	#[serde(skip)]
 	type_table: Interner<AnyTypeId>,

--- a/src/type_def.rs
+++ b/src/type_def.rs
@@ -41,7 +41,6 @@ pub struct TypeDef<F: Form = MetaForm> {
 	/// correct instantiations of a generic type.
 	generic_params: GenericParams<F>,
 	/// The underlying structure of the type definition.
-	#[serde(flatten)]
 	kind: TypeDefKind<F>,
 }
 
@@ -89,7 +88,7 @@ impl TypeDef {
 	pub fn builtin() -> Self {
 		Self {
 			generic_params: GenericParams::empty(),
-			kind: TypeDefKind::Builtin,
+			kind: TypeDefKind::Builtin(Builtin),
 		}
 	}
 
@@ -150,7 +149,7 @@ impl From<<MetaForm as Form>::String> for GenericArg {
 #[serde(bound = "F::TypeId: Serialize")]
 #[serde(untagged)]
 pub enum TypeDefKind<F: Form = MetaForm> {
-	Builtin,
+	Builtin(Builtin),
 	Struct(TypeDefStruct<F>),
 	TupleStruct(TypeDefTupleStruct<F>),
 	ClikeEnum(TypeDefClikeEnum<F>),
@@ -158,12 +157,17 @@ pub enum TypeDefKind<F: Form = MetaForm> {
 	Union(TypeDefUnion<F>),
 }
 
+/// This struct just exists for the purpose of better JSON output.
+#[derive(PartialEq, Eq, Debug, Serialize)]
+#[serde(rename = "builtin")]
+pub struct Builtin;
+
 impl IntoCompact for TypeDefKind {
 	type Output = TypeDefKind<CompactForm>;
 
 	fn into_compact(self, registry: &mut Registry) -> Self::Output {
 		match self {
-			TypeDefKind::Builtin => TypeDefKind::Builtin,
+			TypeDefKind::Builtin(builtin) => TypeDefKind::Builtin(builtin),
 			TypeDefKind::Struct(r#struct) => r#struct.into_compact(registry).into(),
 			TypeDefKind::TupleStruct(tuple_struct) => tuple_struct.into_compact(registry).into(),
 			TypeDefKind::ClikeEnum(clike_enum) => clike_enum.into_compact(registry).into(),

--- a/src/type_def.rs
+++ b/src/type_def.rs
@@ -88,7 +88,7 @@ impl TypeDef {
 	pub fn builtin() -> Self {
 		Self {
 			generic_params: GenericParams::empty(),
-			kind: TypeDefKind::Builtin(Builtin),
+			kind: TypeDefKind::Builtin(Builtin::Builtin),
 		}
 	}
 
@@ -159,8 +159,10 @@ pub enum TypeDefKind<F: Form = MetaForm> {
 
 /// This struct just exists for the purpose of better JSON output.
 #[derive(PartialEq, Eq, Debug, Serialize)]
-#[serde(rename = "builtin")]
-pub struct Builtin;
+pub enum Builtin {
+	#[serde(rename = "builtin")]
+	Builtin,
+}
 
 impl IntoCompact for TypeDefKind {
 	type Output = TypeDefKind<CompactForm>;

--- a/src/type_def.rs
+++ b/src/type_def.rs
@@ -147,6 +147,7 @@ impl From<<MetaForm as Form>::String> for GenericArg {
 
 #[derive(PartialEq, Eq, Debug, Serialize, From)]
 #[serde(bound = "F::TypeId: Serialize")]
+#[serde(untagged)]
 pub enum TypeDefKind<F: Form = MetaForm> {
 	Builtin,
 	Struct(TypeDefStruct<F>),
@@ -174,6 +175,7 @@ impl IntoCompact for TypeDefKind {
 #[derive(PartialEq, Eq, Debug, Serialize)]
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct TypeDefStruct<F: Form = MetaForm> {
+	#[serde(rename = "struct.fields")]
 	fields: Vec<NamedField<F>>,
 }
 
@@ -237,6 +239,7 @@ impl NamedField {
 #[derive(PartialEq, Eq, Debug, Serialize)]
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct TypeDefTupleStruct<F: Form = MetaForm> {
+	#[serde(rename = "tuple_struct.types")]
 	fields: Vec<UnnamedField<F>>,
 }
 
@@ -271,6 +274,7 @@ impl TypeDefTupleStruct {
 
 #[derive(PartialEq, Eq, Debug, Serialize)]
 #[serde(bound = "F::TypeId: Serialize")]
+#[serde(transparent)]
 pub struct UnnamedField<F: Form = MetaForm> {
 	#[serde(rename = "type")]
 	ty: F::TypeId,
@@ -301,7 +305,9 @@ impl UnnamedField {
 
 #[derive(PartialEq, Eq, Debug, Serialize)]
 #[serde(bound = "F::TypeId: Serialize")]
+#[serde(transparent)]
 pub struct TypeDefClikeEnum<F: Form = MetaForm> {
+	#[serde(rename = "clike_enum.variants")]
 	variants: Vec<ClikeEnumVariant<F>>,
 }
 
@@ -361,7 +367,9 @@ impl ClikeEnumVariant {
 
 #[derive(PartialEq, Eq, Debug, Serialize)]
 #[serde(bound = "F::TypeId: Serialize")]
+#[serde(transparent)]
 pub struct TypeDefEnum<F: Form = MetaForm> {
+	#[serde(rename = "enum.variants")]
 	variants: Vec<EnumVariant<F>>,
 }
 
@@ -392,6 +400,7 @@ impl TypeDefEnum {
 
 #[derive(PartialEq, Eq, Debug, Serialize, From)]
 #[serde(bound = "F::TypeId: Serialize")]
+#[serde(untagged)]
 pub enum EnumVariant<F: Form = MetaForm> {
 	Unit(EnumVariantUnit<F>),
 	Struct(EnumVariantStruct<F>),
@@ -411,7 +420,9 @@ impl IntoCompact for EnumVariant {
 }
 
 #[derive(PartialEq, Eq, Debug, Serialize)]
+#[serde(transparent)]
 pub struct EnumVariantUnit<F: Form = MetaForm> {
+	#[serde(rename = "unit_variant.name")]
 	name: F::String,
 }
 
@@ -434,7 +445,10 @@ impl EnumVariantUnit {
 #[derive(PartialEq, Eq, Debug, Serialize)]
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct EnumVariantStruct<F: Form = MetaForm> {
+	#[serde(rename = "struct_variant.name")]
 	name: F::String,
+	#[serde(rename = "struct_variant.fields")]
+	#[serde(flatten)]
 	fields: Vec<NamedField<F>>,
 }
 
@@ -468,7 +482,10 @@ impl EnumVariantStruct {
 #[derive(PartialEq, Eq, Debug, Serialize)]
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct EnumVariantTupleStruct<F: Form = MetaForm> {
+	#[serde(rename = "tuple_struct_variant.name")]
 	name: F::String,
+	#[serde(rename = "tuple_struct.types")]
+	#[serde(flatten)]
 	fields: Vec<UnnamedField<F>>,
 }
 
@@ -501,7 +518,9 @@ impl EnumVariantTupleStruct {
 
 #[derive(PartialEq, Eq, Debug, Serialize)]
 #[serde(bound = "F::TypeId: Serialize")]
+#[serde(transparent)]
 pub struct TypeDefUnion<F: Form = MetaForm> {
+	#[serde(rename = "union.fields")]
 	fields: Vec<NamedField<F>>,
 }
 

--- a/src/type_def.rs
+++ b/src/type_def.rs
@@ -41,6 +41,7 @@ pub struct TypeDef<F: Form = MetaForm> {
 	/// correct instantiations of a generic type.
 	generic_params: GenericParams<F>,
 	/// The underlying structure of the type definition.
+	#[serde(flatten)]
 	kind: TypeDefKind<F>,
 }
 

--- a/src/type_def.rs
+++ b/src/type_def.rs
@@ -99,6 +99,7 @@ impl TypeDef {
 
 #[derive(PartialEq, Eq, Debug, Serialize, From)]
 #[serde(bound = "F::TypeId: Serialize")]
+#[serde(transparent)]
 pub struct GenericParams<F: Form = MetaForm> {
 	params: Vec<GenericArg<F>>,
 }

--- a/src/type_id.rs
+++ b/src/type_id.rs
@@ -106,6 +106,7 @@ impl Namespace {
 	F::TypeId: Serialize,
 	F::IndirectTypeId: Serialize
 ")]
+#[serde(untagged)]
 pub enum TypeId<F: Form = MetaForm> {
 	Custom(TypeIdCustom<F>),
 	Slice(TypeIdSlice<F>),
@@ -130,7 +131,6 @@ impl IntoCompact for TypeId {
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug)]
 #[serde(rename_all = "lowercase")]
-#[serde(untagged)]
 pub enum TypeIdPrimitive {
 	Bool,
 	Char,
@@ -150,9 +150,11 @@ pub enum TypeIdPrimitive {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug)]
 #[serde(bound = "F::TypeId: Serialize")]
 pub struct TypeIdCustom<F: Form = MetaForm> {
+	#[serde(rename = "custom.name")]
 	name: F::String,
+	#[serde(rename = "custom.namespace")]
 	namespace: Namespace<F>,
-	#[serde(rename = "type")]
+	#[serde(rename = "custom.params")]
 	type_params: Vec<F::TypeId>,
 }
 
@@ -188,8 +190,9 @@ impl TypeIdCustom {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug)]
 #[serde(bound = "F::IndirectTypeId: Serialize")]
 pub struct TypeIdArray<F: Form = MetaForm> {
+	#[serde(rename = "array.len")]
 	pub len: u16,
-	#[serde(rename = "type")]
+	#[serde(rename = "array.type")]
 	pub type_param: F::IndirectTypeId,
 }
 
@@ -212,8 +215,8 @@ impl TypeIdArray {
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug)]
 #[serde(bound = "F::TypeId: Serialize")]
+#[serde(transparent)]
 pub struct TypeIdTuple<F: Form = MetaForm> {
-	#[serde(rename = "type")]
 	pub type_params: Vec<F::TypeId>,
 }
 
@@ -249,7 +252,7 @@ impl TypeIdTuple {
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug)]
 #[serde(bound = "F::IndirectTypeId: Serialize")]
 pub struct TypeIdSlice<F: Form = MetaForm> {
-	#[serde(rename = "type")]
+	#[serde(rename = "slice.type")]
 	type_param: F::IndirectTypeId,
 }
 

--- a/src/type_id.rs
+++ b/src/type_id.rs
@@ -37,6 +37,7 @@ pub trait HasTypeId {
 ///
 /// Rust prelude type may have an empty namespace definition.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug)]
+#[serde(transparent)]
 pub struct Namespace<F: Form = MetaForm> {
 	/// The segments of the namespace.
 	segments: Vec<F::String>,

--- a/src/type_id.rs
+++ b/src/type_id.rs
@@ -130,6 +130,7 @@ impl IntoCompact for TypeId {
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug)]
 #[serde(rename_all = "lowercase")]
+#[serde(untagged)]
 pub enum TypeIdPrimitive {
 	Bool,
 	Char,


### PR DESCRIPTION
ToDo:

- [x] Simplify `def` sections, especially for `builtin` type definitions.
- [ ] ~~Merge `id` and `def` sub-sections for `types` registry section.~~

Intermediate result as an example encoding for the Flipper smart contract using ink!:
```json
{
	"registry": {
		"strings": [
			"Flipper",
			"contract",
			"value",
			"Value",
			"ink_core",
			"storage",
			"cell",
			"SyncCell",
			"sync_cell",
			"Key",
			"key",
			"flip",
			"get"
		],
		"types": [
			{
				"id": {
					"custom.name": 1,
					"custom.namespace": [
						2
					],
					"custom.params": []
				},
				"def": "builtin"
			},
			{
				"id": "bool",
				"def": "builtin"
			},
			{
				"id": "u8",
				"def": "builtin"
			},
			{
				"id": {
					"array.len": 32,
					"array.type": 7
				},
				"def": "builtin"
			},
			{
				"id": {
					"custom.name": 10,
					"custom.namespace": [
						5,
						6,
						11
					],
					"custom.params": []
				},
				"def": {
					"tuple_struct.types": [
						6
					]
				}
			},
			{
				"id": {
					"custom.name": 8,
					"custom.namespace": [
						5,
						6,
						7,
						9
					],
					"custom.params": [
						3
					]
				},
				"def": {
					"struct.fields": [
						{
							"name": 7,
							"type": 5
						}
					]
				}
			},
			{
				"id": {
					"custom.name": 4,
					"custom.namespace": [
						5,
						6,
						3
					],
					"custom.params": [
						3
					]
				},
				"def": {
					"struct.fields": [
						{
							"name": 7,
							"type": 4
						}
					]
				}
			}
		]
	},
	"storage": {
		"struct.type": 1,
		"struct.fields": [
			{
				"name": 3,
				"layout": {
					"struct.type": 2,
					"struct.fields": [
						{
							"name": 7,
							"layout": {
								"range.offset": [
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0,
									0
								],
								"range.len": 1,
								"range.elem_type": 3
							}
						}
					]
				}
			}
		]
	},
	"contract": {
		"name": 1,
		"deploy": {
			"args": [],
			"docs": [
				"The internal boolean is initialized with `true`."
			]
		},
		"messages": [
			{
				"name": 12,
				"selector": 970692492,
				"mutates": true,
				"args": [],
				"return_type": null,
				"docs": []
			},
			{
				"name": 13,
				"selector": 4266279973,
				"mutates": false,
				"args": [],
				"return_type": 3,
				"docs": []
			}
		],
		"events": [],
		"docs": [
			"A simple contract that has a boolean value that can be flipped and be returned."
		]
	}
}
```