### PR TITLE
Fix serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,12 @@ derive_more = { version = "0.15", features = ["no_std"] }
 
 [features]
 default = ["std"]
-std = []
-derive = ["type-metadata-derive"]
+std = [
+    "serde/std",
+]
+derive = [
+    "type-metadata-derive"
+]
 
 [workspace]
 members = [

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -42,13 +42,13 @@ pub struct Registry {
 	#[serde(skip)]
 	type_table: Interner<AnyTypeId>,
 	#[serde(serialize_with = "serialize_registry_types")]
-	types: BTreeMap<UntrackedSymbol<std::any::TypeId>, TypeIdDef>,
+	types: BTreeMap<UntrackedSymbol<core::any::TypeId>, TypeIdDef>,
 }
 
 /// Serializes the types of the registry by removing their unique IDs
 /// and instead serialize them in order of their removed unique ID.
 fn serialize_registry_types<S>(
-	types: &BTreeMap<UntrackedSymbol<std::any::TypeId>, TypeIdDef>,
+	types: &BTreeMap<UntrackedSymbol<core::any::TypeId>, TypeIdDef>,
 	serializer: S,
 ) -> Result<S::Ok, S::Error>
 where

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -54,7 +54,7 @@ fn serialize_registry_types<S>(
 where
     S: serde::Serializer
 {
-    let types = types.iter().collect::<Vec<_>>();
+    let types = types.values().collect::<Vec<_>>();
     types.serialize(serializer)
 }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -41,21 +41,21 @@ pub struct Registry {
 	string_table: Interner<&'static str>,
 	#[serde(skip)]
 	type_table: Interner<AnyTypeId>,
-    #[serde(serialize_with = "serialize_registry_types")]
+	#[serde(serialize_with = "serialize_registry_types")]
 	types: BTreeMap<UntrackedSymbol<std::any::TypeId>, TypeIdDef>,
 }
 
 /// Serializes the types of the registry by removing their unique IDs
 /// and instead serialize them in order of their removed unique ID.
 fn serialize_registry_types<S>(
-    types: &BTreeMap<UntrackedSymbol<std::any::TypeId>, TypeIdDef>,
-    serializer: S,
+	types: &BTreeMap<UntrackedSymbol<std::any::TypeId>, TypeIdDef>,
+	serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
-    S: serde::Serializer
+	S: serde::Serializer,
 {
-    let types = types.values().collect::<Vec<_>>();
-    types.serialize(serializer)
+	let types = types.values().collect::<Vec<_>>();
+	types.serialize(serializer)
 }
 
 impl Registry {
@@ -102,10 +102,13 @@ impl Registry {
 		if inserted {
 			let compact_id = ty.type_id().into_compact(self);
 			let compact_def = ty.type_def().into_compact(self);
-			self.types.insert(symbol, TypeIdDef {
-				id: compact_id,
-				def: compact_def,
-			});
+			self.types.insert(
+				symbol,
+				TypeIdDef {
+					id: compact_id,
+					def: compact_def,
+				},
+			);
 		}
 		symbol
 	}


### PR DESCRIPTION
Fixes the ordering of types serialization.
Previously was serialized in the reverse order.
Now is serialized in the order of the unique ID of the respective type.