### PR TITLE
Add JSON serialize tests

### DIFF
--- a/src/type_def.rs
+++ b/src/type_def.rs
@@ -382,7 +382,6 @@ impl ClikeEnumVariant {
 /// ```
 #[derive(PartialEq, Eq, Debug, Serialize)]
 #[serde(bound = "F::TypeId: Serialize")]
-#[serde(transparent)]
 pub struct TypeDefEnum<F: Form = MetaForm> {
 	/// The variants of the enum.
 	#[serde(rename = "enum.variants")]
@@ -459,10 +458,9 @@ impl IntoCompact for EnumVariant {
 /// }
 /// ```
 #[derive(PartialEq, Eq, Debug, Serialize)]
-#[serde(transparent)]
 pub struct EnumVariantUnit<F: Form = MetaForm> {
 	/// The name of the variant.
-	#[serde(rename = "unit_struct_variant.name")]
+	#[serde(rename = "unit_variant.name")]
 	name: F::String,
 }
 

--- a/src/type_def.rs
+++ b/src/type_def.rs
@@ -280,7 +280,6 @@ impl UnnamedField {
 /// ```
 #[derive(PartialEq, Eq, Debug, Serialize)]
 #[serde(bound = "F::TypeId: Serialize")]
-#[serde(transparent)]
 pub struct TypeDefClikeEnum<F: Form = MetaForm> {
 	/// The variants of the C-like enum.
 	#[serde(rename = "clike_enum.variants")]

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -11,3 +11,6 @@ license = "Apache-2.0"
 
 [dependencies]
 type-metadata = { path = "..", features = ["derive"] }
+
+serde = "1.0"
+serde_json = "1.0"

--- a/test_suite/derive_tests_no_std/Cargo.toml
+++ b/test_suite/derive_tests_no_std/Cargo.toml
@@ -10,7 +10,8 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = { version = "0.2", default-features = false }
 type-metadata = { path = "../..", default-features = false, features = ["derive"] }
+
+libc = { version = "0.2", default-features = false }
 
 [workspace]

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -1,3 +1,18 @@
+// Copyright 2019
+//     by  Centrality Investments Ltd.
+//     and Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -10,162 +25,148 @@ use alloc::{boxed::Box, vec};
 use serde::Serialize;
 use serde_json::json;
 use type_metadata::{
-    HasTypeId as _,
-    HasTypeDef as _,
-    IntoCompact as _,
-    form::CompactForm,
-    TypeId,
-    TypeDef,
-    Metadata,
-    Registry,
+	form::CompactForm, HasTypeDef as _, HasTypeId as _, IntoCompact as _, Metadata, Registry, TypeDef, TypeId,
 };
 
 #[derive(Serialize)]
 struct TypeIdDef {
-    id: TypeId<CompactForm>,
-    def: TypeDef<CompactForm>,
+	id: TypeId<CompactForm>,
+	def: TypeDef<CompactForm>,
 }
 
 fn assert_json_for_type<T>(expected_json: serde_json::Value)
 where
-    T: Metadata,
+	T: Metadata,
 {
-    let mut registry = Registry::new();
+	let mut registry = Registry::new();
 
-    let type_id = T::type_id().into_compact(&mut registry);
-    let type_def = T::type_def().into_compact(&mut registry);
-    let id_def = TypeIdDef {
-        id: type_id,
-        def: type_def,
-    };
+	let type_id = T::type_id().into_compact(&mut registry);
+	let type_def = T::type_def().into_compact(&mut registry);
+	let id_def = TypeIdDef {
+		id: type_id,
+		def: type_def,
+	};
 
-    assert_eq!(
-        serde_json::to_value(id_def).unwrap(),
-        expected_json,
-    );
+	assert_eq!(serde_json::to_value(id_def).unwrap(), expected_json,);
 }
 
 #[test]
 fn test_unit_struct() {
-    #[derive(Metadata)]
-    struct UnitStruct;
+	#[derive(Metadata)]
+	struct UnitStruct;
 
-    assert_json_for_type::<UnitStruct>(json!({
-        "id": {
-            "custom.name": 1,
-            "custom.namespace": [2],
-            "custom.params": [],
-        },
-        "def": {
-            "tuple_struct.types": []
-        },
-    }));
+	assert_json_for_type::<UnitStruct>(json!({
+		"id": {
+			"custom.name": 1,
+			"custom.namespace": [2],
+			"custom.params": [],
+		},
+		"def": {
+			"tuple_struct.types": []
+		},
+	}));
 }
 
 #[test]
 fn test_tuple_struct() {
-    #[derive(Metadata)]
-    struct TupleStruct(i32, [u8; 32], bool);
+	#[derive(Metadata)]
+	struct TupleStruct(i32, [u8; 32], bool);
 
-    assert_json_for_type::<TupleStruct>(json!({
-        "id": {
-            "custom.name": 1,
-            "custom.namespace": [2],
-            "custom.params": [],
-        },
-        "def": {
-            "tuple_struct.types": [1, 2, 4]
-        },
-    }));
+	assert_json_for_type::<TupleStruct>(json!({
+		"id": {
+			"custom.name": 1,
+			"custom.namespace": [2],
+			"custom.params": [],
+		},
+		"def": {
+			"tuple_struct.types": [1, 2, 4]
+		},
+	}));
 }
 
 #[test]
 fn test_struct() {
-    #[derive(Metadata)]
-    struct Struct {
-        a: i32,
-        b: [u8; 32],
-        c: bool,
-    }
+	#[derive(Metadata)]
+	struct Struct {
+		a: i32,
+		b: [u8; 32],
+		c: bool,
+	}
 
-    assert_json_for_type::<Struct>(json!({
-        "id": {
-            "custom.name": 1,
-            "custom.namespace": [2],
-            "custom.params": [],
-        },
-        "def": {
-            "struct.fields": [
-                { "name": 3, "type": 1, },
-                { "name": 4, "type": 2, },
-                { "name": 5, "type": 4, },
-            ]
-        },
-    }));
+	assert_json_for_type::<Struct>(json!({
+		"id": {
+			"custom.name": 1,
+			"custom.namespace": [2],
+			"custom.params": [],
+		},
+		"def": {
+			"struct.fields": [
+				{ "name": 3, "type": 1, },
+				{ "name": 4, "type": 2, },
+				{ "name": 5, "type": 4, },
+			]
+		},
+	}));
 }
 
 #[test]
 fn test_clike_enum() {
-    #[derive(Metadata)]
-    enum ClikeEnum {
-        A,
-        B = 42,
-        C,
-    }
+	#[derive(Metadata)]
+	enum ClikeEnum {
+		A,
+		B = 42,
+		C,
+	}
 
-    assert_json_for_type::<ClikeEnum>(json!({
-        "id": {
-            "custom.name": 1,
-            "custom.namespace": [2],
-            "custom.params": [],
-        },
-        "def": {
-            "clike_enum.variants": [
-                { "name": 3, "discriminant": 0, },
-                { "name": 4, "discriminant": 42, },
-                { "name": 5, "discriminant": 2, },
-            ]
-        },
-    }));
+	assert_json_for_type::<ClikeEnum>(json!({
+		"id": {
+			"custom.name": 1,
+			"custom.namespace": [2],
+			"custom.params": [],
+		},
+		"def": {
+			"clike_enum.variants": [
+				{ "name": 3, "discriminant": 0, },
+				{ "name": 4, "discriminant": 42, },
+				{ "name": 5, "discriminant": 2, },
+			]
+		},
+	}));
 }
 
 #[test]
 fn test_enum() {
-    #[derive(Metadata)]
-    enum Enum {
-        ClikeVariant,
-        TupleStructVariant(u32, bool),
-        StructVariant {
-            a: u32,
-            b: [u8; 32],
-            c: char,
-        },
-    }
+	#[derive(Metadata)]
+	enum Enum {
+		ClikeVariant,
+		TupleStructVariant(u32, bool),
+		StructVariant { a: u32, b: [u8; 32], c: char },
+	}
 
-    assert_json_for_type::<Enum>(json!({
-        "id": {
-            "custom.name": 1,
-            "custom.namespace": [2],
-            "custom.params": [],
-        },
-        "def": {
-            "enum.variants": [
-                {
-                    "unit_variant.name": 3,
-                },
-                {
-                    "tuple_struct_variant.name": 4,
-                    "tuple_struct_variant.types": [1, 2],
-                },
-                {
-                    "struct_variant.name": 5,
-                    "struct_variant.fields": [
-                        { "name": 6, "type": 1, },
-                        { "name": 7, "type": 3, },
-                        { "name": 8, "type": 5, },
-                    ],
-                }
-            ]
-        },
-    }));
+	assert_json_for_type::<Enum>(json!({
+		"id": {
+			"custom.name": 1,
+			"custom.namespace": [2],
+			"custom.params": [],
+		},
+		"def": {
+			"enum.variants": [
+				{
+					"unit_variant.name": 3,
+				},
+				{
+					"tuple_struct_variant.name": 4,
+					"tuple_struct_variant.types": [1, 2],
+				},
+				{
+					"struct_variant.name": 5,
+					"struct_variant.fields": [
+						{ "name": 6, "type": 1, },
+						{ "name": 7, "type": 3, },
+						{ "name": 8, "type": 5, },
+					],
+				}
+			]
+		},
+	}));
 }

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -1,0 +1,80 @@
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, vec};
+
+use serde::Serialize;
+use serde_json::json;
+use type_metadata::{
+    HasTypeId as _,
+    HasTypeDef as _,
+    IntoCompact as _,
+    form::CompactForm,
+    TypeId,
+    TypeDef,
+    Metadata,
+    Registry,
+};
+
+#[derive(Serialize)]
+struct TypeIdDef {
+    id: TypeId<CompactForm>,
+    def: TypeDef<CompactForm>,
+}
+
+fn assert_json_for_type<T>(expected_json: serde_json::Value)
+where
+    T: Metadata,
+{
+    let mut registry = Registry::new();
+
+    let type_id = T::type_id().into_compact(&mut registry);
+    let type_def = T::type_def().into_compact(&mut registry);
+    let id_def = TypeIdDef {
+        id: type_id,
+        def: type_def,
+    };
+
+    assert_eq!(
+        serde_json::to_value(id_def).unwrap(),
+        expected_json,
+    );
+}
+
+#[test]
+fn test_unit_struct() {
+    #[derive(Metadata)]
+    struct UnitStruct;
+
+    assert_json_for_type::<UnitStruct>(json!({
+        "id": {
+            "custom.name": 1,
+            "custom.namespace": [2],
+            "custom.params": [],
+        },
+        "def": {
+            "tuple_struct.types": []
+        },
+    }));
+}
+
+#[test]
+fn test_tuple_struct() {
+    #[derive(Metadata)]
+    struct TupleStruct(i32, [u8; 32], bool);
+
+    assert_json_for_type::<TupleStruct>(json!({
+        "id": {
+            "custom.name": 1,
+            "custom.namespace": [2],
+            "custom.params": [],
+        },
+        "def": {
+            "tuple_struct.types": [1, 2, 4]
+        },
+    }));
+}

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -103,3 +103,28 @@ fn test_struct() {
         },
     }));
 }
+
+#[test]
+fn test_clike_enum() {
+    #[derive(Metadata)]
+    enum ClikeEnum {
+        A,
+        B = 42,
+        C,
+    }
+
+    assert_json_for_type::<ClikeEnum>(json!({
+        "id": {
+            "custom.name": 1,
+            "custom.namespace": [2],
+            "custom.params": [],
+        },
+        "def": {
+            "clike_enum.variants": [
+                { "name": 3, "discriminant": 0, },
+                { "name": 4, "discriminant": 42, },
+                { "name": 5, "discriminant": 2, },
+            ]
+        },
+    }));
+}

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -128,3 +128,44 @@ fn test_clike_enum() {
         },
     }));
 }
+
+#[test]
+fn test_enum() {
+    #[derive(Metadata)]
+    enum Enum {
+        ClikeVariant,
+        TupleStructVariant(u32, bool),
+        StructVariant {
+            a: u32,
+            b: [u8; 32],
+            c: char,
+        },
+    }
+
+    assert_json_for_type::<Enum>(json!({
+        "id": {
+            "custom.name": 1,
+            "custom.namespace": [2],
+            "custom.params": [],
+        },
+        "def": {
+            "enum.variants": [
+                {
+                    "unit_variant.name": 3,
+                },
+                {
+                    "tuple_struct_variant.name": 4,
+                    "tuple_struct_variant.types": [1, 2],
+                },
+                {
+                    "struct_variant.name": 5,
+                    "struct_variant.fields": [
+                        { "name": 6, "type": 1, },
+                        { "name": 7, "type": 3, },
+                        { "name": 8, "type": 5, },
+                    ],
+                }
+            ]
+        },
+    }));
+}

--- a/test_suite/tests/json.rs
+++ b/test_suite/tests/json.rs
@@ -78,3 +78,28 @@ fn test_tuple_struct() {
         },
     }));
 }
+
+#[test]
+fn test_struct() {
+    #[derive(Metadata)]
+    struct Struct {
+        a: i32,
+        b: [u8; 32],
+        c: bool,
+    }
+
+    assert_json_for_type::<Struct>(json!({
+        "id": {
+            "custom.name": 1,
+            "custom.namespace": [2],
+            "custom.params": [],
+        },
+        "def": {
+            "struct.fields": [
+                { "name": 3, "type": 1, },
+                { "name": 4, "type": 2, },
+                { "name": 5, "type": 4, },
+            ]
+        },
+    }));
+}


### PR DESCRIPTION
Adds JSON output tests for `type-metadata` to make JSON output stable.
This tests the compactified JSON output of `TypeId` and `TypeDef` of some concrete types.

Also this PR includes fixes of bugs revealed by the new tests.