### PR TITLE
Fix PhantomData HasTypeId and HasTypeDef impls

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -275,10 +275,10 @@ impl HasTypeDef for String {
 
 impl<T> HasTypeId for PhantomData<T>
 where
-	T: HasTypeId + ?Sized,
+	T: Metadata + ?Sized,
 {
 	fn type_id() -> TypeId {
-		<T>::type_id()
+		TypeIdCustom::new("PhantomData", Namespace::prelude(), vec![T::meta_type()]).into()
 	}
 }
 
@@ -287,6 +287,6 @@ where
 	T: Metadata + ?Sized,
 {
 	fn type_def() -> TypeDef {
-		TypeDef::builtin()
+		TypeDefTupleStruct::new(vec![]).into()
 	}
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -44,7 +44,6 @@ fn primitives() {
 	assert_type_id!(Box<String>, TypeIdPrimitive::Str);
 	assert_type_id!(&String, TypeIdPrimitive::Str);
 	assert_type_id!([bool], TypeIdSlice::new(bool::meta_type()));
-	assert_type_id!(PhantomData<bool>, TypeIdPrimitive::Bool);
 }
 
 #[test]
@@ -57,6 +56,10 @@ fn prelude_items() {
 		Result<bool, String>,
 		TypeIdCustom::new("Result", Namespace::prelude(), tuple_meta_type!(bool, String))
 	);
+	assert_type_id!(
+		PhantomData<i32>,
+		TypeIdCustom::new("PhantomData", Namespace::prelude(), tuple_meta_type!(i32))
+	)
 }
 
 #[test]


### PR DESCRIPTION
This causes huge troubles in the ink! codebase.
The underlying problem is that the current implementation of `PhantomData` does not respect the required invariance that all unique types should have a unique type ID since since `PhantomData<T>` and `T` share a common type ID in the current implementation.

The fix is that now `PhantomData<T>` also has its own unique ID. Besides that it is no longer marked as `builtin` since it basically is an empty tuple-struct and thus should be treated as such. This caused problem in the Polkadot JS UI.