### PR TITLE
Solang requires non-static names of contract, messages, types etc.

### DIFF
--- a/derive/src/type_def.rs
+++ b/derive/src/type_def.rs
@@ -68,7 +68,7 @@ fn generate_fields_def(fields: &FieldsList) -> TokenStream2 {
 		};
 		if let Some(i) = ident {
 			quote! {
-				_type_metadata::NamedField::new(stringify!(#i), #meta_type)
+				_type_metadata::NamedField::new(stringify!(#i).into(), #meta_type)
 			}
 		} else {
 			quote! {
@@ -119,7 +119,7 @@ fn generate_c_like_enum_def(variants: &VariantList) -> TokenStream2 {
 			i as u64
 		};
 		quote! {
-			_type_metadata::ClikeEnumVariant::new(stringify!(#name), #discriminant)
+			_type_metadata::ClikeEnumVariant::new(stringify!(#name).into(), #discriminant)
 		}
 	});
 	quote! {
@@ -146,7 +146,7 @@ fn generate_enum_def(data_enum: &DataEnum) -> TokenStream2 {
 
 	let variants_def = variants.into_iter().map(|v| {
 		let ident = &v.ident;
-		let v_name = quote! {stringify!(#ident) };
+		let v_name = quote! {stringify!(#ident).into() };
 		match v.fields {
 			Fields::Named(ref fs) => {
 				let fields = generate_fields_def(&fs.named);

--- a/derive/src/type_id.rs
+++ b/derive/src/type_id.rs
@@ -47,8 +47,8 @@ pub fn generate_impl(input: TokenStream2) -> Result<TokenStream2> {
 		impl #impl_generics _type_metadata::HasTypeId for #ident #ty_generics #where_clause {
 			fn type_id() -> _type_metadata::TypeId {
 				_type_metadata::TypeIdCustom::new(
-					stringify!(#ident),
-					_type_metadata::Namespace::from_module_path(module_path!())
+					stringify!(#ident).into(),
+					_type_metadata::Namespace::from_module_path(module_path!().into())
 						.expect("namespace from module path cannot fail"),
 					__core::vec![ #( #generic_type_ids ),* ],
 				).into()

--- a/src/form.rs
+++ b/src/form.rs
@@ -61,7 +61,7 @@ pub trait Form {
 pub enum MetaForm {}
 
 impl Form for MetaForm {
-	type String = &'static str;
+	type String = String;
 	type TypeId = MetaType;
 	type IndirectTypeId = MetaType;
 }
@@ -77,7 +77,7 @@ impl Form for MetaForm {
 pub enum CompactForm {}
 
 impl Form for CompactForm {
-	type String = UntrackedSymbol<&'static str>;
+	type String = UntrackedSymbol<String>;
 	type TypeId = UntrackedSymbol<AnyTypeId>;
 	type IndirectTypeId = Self::TypeId;
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -118,7 +118,7 @@ where
 	T: Metadata + 'static,
 {
 	fn type_id() -> TypeId {
-		TypeIdCustom::new("Vec", Namespace::prelude(), tuple_meta_type![T]).into()
+		TypeIdCustom::new("Vec".into(), Namespace::prelude(), tuple_meta_type![T]).into()
 	}
 }
 
@@ -127,7 +127,7 @@ where
 	T: Metadata + 'static,
 {
 	fn type_def() -> TypeDef {
-		TypeDefStruct::new(vec![NamedField::new("elems", MetaType::new::<[T]>())]).into()
+		TypeDefStruct::new(vec![NamedField::new("elems".into(), MetaType::new::<[T]>())]).into()
 	}
 }
 
@@ -136,7 +136,7 @@ where
 	T: Metadata + 'static,
 {
 	fn type_id() -> TypeId {
-		TypeIdCustom::new("Option", Namespace::prelude(), tuple_meta_type![T]).into()
+		TypeIdCustom::new("Option".into(), Namespace::prelude(), tuple_meta_type![T]).into()
 	}
 }
 
@@ -146,8 +146,8 @@ where
 {
 	fn type_def() -> TypeDef {
 		TypeDefEnum::new(vec![
-			EnumVariantUnit::new("None").into(),
-			EnumVariantTupleStruct::new("Some", vec![UnnamedField::of::<T>()]).into(),
+			EnumVariantUnit::new("None".into()).into(),
+			EnumVariantTupleStruct::new("Some".into(), vec![UnnamedField::of::<T>()]).into(),
 		])
 		.into()
 	}
@@ -159,7 +159,7 @@ where
 	E: Metadata + 'static,
 {
 	fn type_id() -> TypeId {
-		TypeIdCustom::new("Result", Namespace::prelude(), tuple_meta_type!(T, E)).into()
+		TypeIdCustom::new("Result".into(), Namespace::prelude(), tuple_meta_type!(T, E)).into()
 	}
 }
 
@@ -170,8 +170,8 @@ where
 {
 	fn type_def() -> TypeDef {
 		TypeDefEnum::new(vec![
-			EnumVariantTupleStruct::new("Ok", vec![UnnamedField::of::<T>()]).into(),
-			EnumVariantTupleStruct::new("Err", vec![UnnamedField::of::<E>()]).into(),
+			EnumVariantTupleStruct::new("Ok".into(), vec![UnnamedField::of::<T>()]).into(),
+			EnumVariantTupleStruct::new("Err".into(), vec![UnnamedField::of::<E>()]).into(),
 		])
 		.into()
 	}
@@ -183,7 +183,7 @@ where
 	V: Metadata + 'static,
 {
 	fn type_id() -> TypeId {
-		TypeIdCustom::new("BTreeMap", Namespace::prelude(), tuple_meta_type!(K, V)).into()
+		TypeIdCustom::new("BTreeMap".into(), Namespace::prelude(), tuple_meta_type!(K, V)).into()
 	}
 }
 
@@ -193,7 +193,7 @@ where
 	V: Metadata + 'static,
 {
 	fn type_def() -> TypeDef {
-		TypeDefStruct::new(vec![NamedField::new("elems", MetaType::new::<[(K, V)]>())]).into()
+		TypeDefStruct::new(vec![NamedField::new("elems".into(), MetaType::new::<[(K, V)]>())]).into()
 	}
 }
 
@@ -289,7 +289,7 @@ impl HasTypeId for String {
 
 impl HasTypeDef for String {
 	fn type_def() -> TypeDef {
-		TypeDefStruct::new(vec![NamedField::new("vec", MetaType::new::<Vec<u8>>())]).into()
+		TypeDefStruct::new(vec![NamedField::new("vec".into(), MetaType::new::<Vec<u8>>())]).into()
 	}
 }
 
@@ -298,7 +298,7 @@ where
 	T: Metadata + ?Sized,
 {
 	fn type_id() -> TypeId {
-		TypeIdCustom::new("PhantomData", Namespace::prelude(), vec![T::meta_type()]).into()
+		TypeIdCustom::new("PhantomData".into(), Namespace::prelude(), vec![T::meta_type()]).into()
 	}
 }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -77,7 +77,7 @@ pub struct TypeIdDef {
 pub struct Registry {
 	/// The cache for already registered strings.
 	#[serde(rename = "strings")]
-	string_table: Interner<&'static str>,
+	string_table: Interner<String>,
 	/// The cache for already registered types.
 	///
 	/// This is just an accessor to the actual database
@@ -122,7 +122,7 @@ impl Registry {
 
 	/// Registeres the given string into the registry and returns
 	/// its respective associated string symbol.
-	pub fn register_string(&mut self, string: &'static str) -> UntrackedSymbol<&'static str> {
+	pub fn register_string(&mut self, string: String) -> UntrackedSymbol<String> {
 		self.string_table.intern_or_get(string).1.into_untracked()
 	}
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -50,15 +50,15 @@ fn primitives() {
 fn prelude_items() {
 	assert_type_id!(
 		Option<u128>,
-		TypeIdCustom::new("Option", Namespace::prelude(), tuple_meta_type!(u128))
+		TypeIdCustom::new("Option".into(), Namespace::prelude(), tuple_meta_type!(u128))
 	);
 	assert_type_id!(
 		Result<bool, String>,
-		TypeIdCustom::new("Result", Namespace::prelude(), tuple_meta_type!(bool, String))
+		TypeIdCustom::new("Result".into(), Namespace::prelude(), tuple_meta_type!(bool, String))
 	);
 	assert_type_id!(
 		PhantomData<i32>,
-		TypeIdCustom::new("PhantomData", Namespace::prelude(), tuple_meta_type!(i32))
+		TypeIdCustom::new("PhantomData".into(), Namespace::prelude(), tuple_meta_type!(i32))
 	)
 }
 
@@ -91,7 +91,7 @@ fn array_primitives() {
 	// vec
 	assert_type_id!(
 		Vec<bool>,
-		TypeIdCustom::new("Vec", Namespace::prelude(), tuple_meta_type![bool])
+		TypeIdCustom::new("Vec".into(), Namespace::prelude(), tuple_meta_type![bool])
 	);
 }
 
@@ -108,8 +108,8 @@ fn struct_with_generics() {
 	{
 		fn type_id() -> TypeId {
 			TypeIdCustom::new(
-				"MyStruct",
-				Namespace::from_module_path(module_path!()).unwrap(),
+				"MyStruct".into(),
+				Namespace::from_module_path(module_path!().into()).unwrap(),
 				tuple_meta_type!(T),
 			)
 			.into()
@@ -121,31 +121,31 @@ fn struct_with_generics() {
 		T: Metadata,
 	{
 		fn type_def() -> TypeDef {
-			TypeDefStruct::new(vec![NamedField::new("data", T::meta_type())]).into()
+			TypeDefStruct::new(vec![NamedField::new("data".into(), T::meta_type())]).into()
 		}
 	}
 
 	// Normal struct
 	let struct_bool_id = TypeIdCustom::new(
-		"MyStruct",
-		Namespace::new(vec!["type_metadata", "tests"]).unwrap(),
+		"MyStruct".into(),
+		Namespace::new(vec!["type_metadata".into(), "tests".into()]).unwrap(),
 		tuple_meta_type!(bool),
 	);
 	assert_type_id!(MyStruct<bool>, struct_bool_id.clone());
 
-	let struct_bool_def = TypeDefStruct::new(vec![NamedField::new("data", bool::meta_type())]).into();
+	let struct_bool_def = TypeDefStruct::new(vec![NamedField::new("data".into(), bool::meta_type())]).into();
 	assert_eq!(<MyStruct<bool>>::type_def(), struct_bool_def);
 
 	// With "`Self` typed" fields
 	type SelfTyped = MyStruct<Box<MyStruct<bool>>>;
 	let expected_type_id = TypeIdCustom::new(
-		"MyStruct",
-		Namespace::new(vec!["type_metadata", "tests"]).unwrap(),
+		"MyStruct".into(),
+		Namespace::new(vec!["type_metadata".into(), "tests".into()]).unwrap(),
 		vec![<Box<MyStruct<bool>>>::meta_type()],
 	);
 	assert_type_id!(SelfTyped, expected_type_id);
 	assert_eq!(
 		SelfTyped::type_def(),
-		TypeDefStruct::new(vec![NamedField::new("data", <Box<MyStruct<bool>>>::meta_type()),]).into(),
+		TypeDefStruct::new(vec![NamedField::new("data".into(), <Box<MyStruct<bool>>>::meta_type()),]).into(),
 	);
 }

--- a/src/type_def.rs
+++ b/src/type_def.rs
@@ -476,7 +476,7 @@ impl IntoCompact for EnumVariantUnit {
 
 impl EnumVariantUnit {
 	/// Creates a new unit struct variant.
-	pub fn new(name: &'static str) -> Self {
+	pub fn new(name: String) -> Self {
 		Self { name }
 	}
 }

--- a/src/type_id.rs
+++ b/src/type_id.rs
@@ -157,6 +157,8 @@ pub enum TypeIdPrimitive {
 	U64,
 	/// `u128`
 	U128,
+	/// no rust equivalent
+	U256,
 	/// `i8`
 	I8,
 	/// `i16`
@@ -167,6 +169,8 @@ pub enum TypeIdPrimitive {
 	I64,
 	/// `i128`
 	I128,
+	/// no rust equivalent
+	I256,
 }
 
 /// A type identifier for custom type definitions.

--- a/src/type_id.rs
+++ b/src/type_id.rs
@@ -92,7 +92,7 @@ impl Namespace {
 	///
 	/// Module path is generally obtained from the `module_path!` Rust macro.
 	pub fn from_module_path(module_path: <MetaForm as Form>::String) -> Result<Self, NamespaceError> {
-		Self::new(module_path.split("::"))
+		Self::new(module_path.split("::").map(|s| s.into()))
 	}
 
 	/// Creates the prelude namespace.
@@ -210,7 +210,7 @@ impl IntoCompact for TypeIdCustom {
 
 impl TypeIdCustom {
 	/// Creates a new type identifier to refer to a custom type definition.
-	pub fn new<T>(name: &'static str, namespace: Namespace, type_params: T) -> Self
+	pub fn new<T>(name: String, namespace: Namespace, type_params: T) -> Self
 	where
 		T: IntoIterator<Item = MetaType>,
 	{
@@ -337,33 +337,38 @@ mod tests {
 	#[test]
 	fn namespace_ok() {
 		assert_eq!(
-			Namespace::new(vec!["hello"]),
+			Namespace::new(vec!["hello".into()]),
 			Ok(Namespace {
-				segments: vec!["hello"]
+				segments: vec!["hello".into()]
 			})
 		);
 		assert_eq!(
-			Namespace::new(vec!["Hello", "World"]),
+			Namespace::new(vec!["Hello".into(), "World".into()]),
 			Ok(Namespace {
-				segments: vec!["Hello", "World"]
+				segments: vec!["Hello".into(), "World".into()]
 			})
 		);
-		assert_eq!(Namespace::new(vec!["_"]), Ok(Namespace { segments: vec!["_"] }));
+		assert_eq!(
+			Namespace::new(vec!["_".into()]),
+			Ok(Namespace {
+				segments: vec!["_".into()]
+			})
+		);
 	}
 
 	#[test]
 	fn namespace_err() {
 		assert_eq!(Namespace::new(vec![]), Err(NamespaceError::MissingSegments));
 		assert_eq!(
-			Namespace::new(vec![""]),
+			Namespace::new(vec!["".into()]),
 			Err(NamespaceError::InvalidIdentifier { segment: 0 })
 		);
 		assert_eq!(
-			Namespace::new(vec!["1"]),
+			Namespace::new(vec!["1".into()]),
 			Err(NamespaceError::InvalidIdentifier { segment: 0 })
 		);
 		assert_eq!(
-			Namespace::new(vec!["Hello", ", World!"]),
+			Namespace::new(vec!["Hello".into(), ", World!".into()]),
 			Err(NamespaceError::InvalidIdentifier { segment: 1 })
 		);
 	}
@@ -371,13 +376,13 @@ mod tests {
 	#[test]
 	fn namespace_from_module_path() {
 		assert_eq!(
-			Namespace::from_module_path("hello::world"),
+			Namespace::from_module_path("hello::world".into()),
 			Ok(Namespace {
-				segments: vec!["hello", "world"]
+				segments: vec!["hello".into(), "world".into()]
 			})
 		);
 		assert_eq!(
-			Namespace::from_module_path("::world"),
+			Namespace::from_module_path("::world".into()),
 			Err(NamespaceError::InvalidIdentifier { segment: 0 })
 		);
 	}

--- a/test_suite/tests/derive.rs
+++ b/test_suite/tests/derive.rs
@@ -51,12 +51,16 @@ fn struct_derive() {
 		pub u: U,
 	}
 
-	let type_id = TypeIdCustom::new("S", Namespace::new(vec!["derive"]).unwrap(), tuple_meta_type!(bool, u8));
+	let type_id = TypeIdCustom::new(
+		"S".into(),
+		Namespace::new(vec!["derive".into()]).unwrap(),
+		tuple_meta_type!(bool, u8),
+	);
 	assert_type_id!(S<bool, u8>, type_id.clone());
 
 	let type_def = TypeDefStruct::new(vec![
-		NamedField::new("t", bool::meta_type()),
-		NamedField::new("u", u8::meta_type()),
+		NamedField::new("t".into(), bool::meta_type()),
+		NamedField::new("u".into(), u8::meta_type()),
 	])
 	.into();
 	assert_eq!(<S<bool, u8>>::type_def(), type_def);
@@ -66,8 +70,8 @@ fn struct_derive() {
 	type SelfTyped = S<Box<S<bool, u8>>, bool>;
 
 	let self_typed_id = TypeIdCustom::new(
-		"S",
-		Namespace::new(vec!["derive"]).unwrap(),
+		"S".into(),
+		Namespace::new(vec!["derive".into()]).unwrap(),
 		tuple_meta_type!(Box<S<bool, u8>>, bool),
 	);
 	assert_type_id!(SelfTyped, self_typed_id);
@@ -75,8 +79,8 @@ fn struct_derive() {
 	assert_eq!(
 		SelfTyped::type_def(),
 		TypeDefStruct::new(vec![
-			NamedField::new("t", <Box<S<bool, u8>>>::meta_type()),
-			NamedField::new("u", bool::meta_type()),
+			NamedField::new("t".into(), <Box<S<bool, u8>>>::meta_type()),
+			NamedField::new("u".into(), bool::meta_type()),
 		])
 		.into(),
 	);
@@ -88,7 +92,11 @@ fn tuple_struct_derive() {
 	#[derive(Metadata)]
 	struct S<T>(T);
 
-	let type_id = TypeIdCustom::new("S", Namespace::new(vec!["derive"]).unwrap(), tuple_meta_type!(bool));
+	let type_id = TypeIdCustom::new(
+		"S".into(),
+		Namespace::new(vec!["derive".into()]).unwrap(),
+		tuple_meta_type!(bool),
+	);
 	assert_type_id!(S<bool>, type_id);
 
 	let type_def = TypeDefTupleStruct::new(vec![UnnamedField::of::<bool>()]).into();
@@ -101,7 +109,7 @@ fn unit_struct_derive() {
 	#[derive(Metadata)]
 	struct S;
 
-	let type_id = TypeIdCustom::new("S", Namespace::new(vec!["derive"]).unwrap(), vec![]);
+	let type_id = TypeIdCustom::new("S".into(), Namespace::new(vec!["derive".into()]).unwrap(), vec![]);
 	assert_type_id!(S, type_id);
 
 	let type_def = TypeDefTupleStruct::unit().into();
@@ -117,12 +125,12 @@ fn c_like_enum_derive() {
 		B = 10,
 	}
 
-	let type_id = TypeIdCustom::new("E", Namespace::new(vec!["derive"]).unwrap(), vec![]);
+	let type_id = TypeIdCustom::new("E".into(), Namespace::new(vec!["derive".into()]).unwrap(), vec![]);
 	assert_type_id!(E, type_id);
 
 	let type_def = TypeDefClikeEnum::new(vec![
-		ClikeEnumVariant::new("A", 0u64),
-		ClikeEnumVariant::new("B", 10u64),
+		ClikeEnumVariant::new("A".into(), 0u64),
+		ClikeEnumVariant::new("B".into(), 10u64),
 	])
 	.into();
 	assert_eq!(E::type_def(), type_def);
@@ -138,13 +146,17 @@ fn enum_derive() {
 		C,
 	}
 
-	let type_id = TypeIdCustom::new("E", Namespace::new(vec!["derive"]).unwrap(), tuple_meta_type!(bool));
+	let type_id = TypeIdCustom::new(
+		"E".into(),
+		Namespace::new(vec!["derive".into()]).unwrap(),
+		tuple_meta_type!(bool),
+	);
 	assert_type_id!(E<bool>, type_id);
 
 	let type_def = TypeDefEnum::new(vec![
-		EnumVariantTupleStruct::new("A", vec![UnnamedField::of::<bool>()]).into(),
-		EnumVariantStruct::new("B", vec![NamedField::new("b", bool::meta_type())]).into(),
-		EnumVariantUnit::new("C").into(),
+		EnumVariantTupleStruct::new("A".into(), vec![UnnamedField::of::<bool>()]).into(),
+		EnumVariantStruct::new("B".into(), vec![NamedField::new("b".into(), bool::meta_type())]).into(),
+		EnumVariantUnit::new("C".into()).into(),
 	])
 	.into();
 	assert_eq!(<E<bool>>::type_def(), type_def);
@@ -159,9 +171,13 @@ fn union_derive() {
 		u: T,
 	}
 
-	let type_id = TypeIdCustom::new("U", Namespace::new(vec!["derive"]).unwrap(), tuple_meta_type!(bool));
+	let type_id = TypeIdCustom::new(
+		"U".into(),
+		Namespace::new(vec!["derive".into()]).unwrap(),
+		tuple_meta_type!(bool),
+	);
 	assert_type_id!(U<bool>, type_id);
 
-	let type_def = TypeDefUnion::new(vec![NamedField::new("u", bool::meta_type())]).into();
+	let type_def = TypeDefUnion::new(vec![NamedField::new("u".into(), bool::meta_type())]).into();
 	assert_eq!(<U<bool>>::type_def(), type_def);
 }


### PR DESCRIPTION
Solang compiles sources files so contract names etc cannot be 'static.